### PR TITLE
This bundle doesn't work on symfony 2.6. This PR fixed this problem.

### DIFF
--- a/Rollbar/Environment.php
+++ b/Rollbar/Environment.php
@@ -60,7 +60,7 @@ class Environment extends BaseEnvironment
     {
         parent::setDefaultOptions($resolver);
 
-        $resolver->replaceDefaults(
+        $resolver->setDefaults(
             array(
                 'framework' => Kernel::VERSION
             )


### PR DESCRIPTION
On symfony 2.6 i've got an exception:

```
UndefinedOptionsException in OptionsResolver.php line 738:
The options "branch", "environment", "root_dir" do not exist. Known options are: "framework".
```

The reason is that the Environment class use `replaceDefault` function on a resolver object(`Symfony\Component\OptionsResolver\OptionsResolverInterface` in `Rollbar/Environment:setDefaultOptions` function) that clear all default options and defined params in this resolver object.

I've changed it to `setDefault` and it works good on symfony 2.5 and symfony 2.6 as well.
