### PR TITLE
Fixed simple string reporting 

### DIFF
--- a/Twig/RollbarExtension.php
+++ b/Twig/RollbarExtension.php
@@ -128,8 +128,24 @@ END_HTML;
         return false;
     }
 
+    function isLogMessage(payload) {
+        try {
+            if (payload.data.body.message !== undefined) {
+                return true;
+            }
+        } catch (e) {
+        }
+
+        return false;
+    }
+
     function ignoreRemoteUncaught(isUncaught, args, payload) {
         try {
+            //this prevents breaking simple string reporting
+            if (isLogMessage(payload)) {
+                return false;
+            }
+
             var filename = payload.data.body.trace.frames[0].filename;
             if (isUncaught && !isFromAllowedHosts(filename)) {
                 return true;


### PR DESCRIPTION
The ignoreRemoteUncaught function failed to recognise following cases: 

```
Rollbar.critical("Connection error from remote Payments API");
Rollbar.error("Some unexpected condition");
Rollbar.warning("Connection error from Twitter API");
Rollbar.info("User opened the purchase dialog");
Rollbar.debug("Purchase dialog finished rendering");
```

In those since there is no frame or filename, the report would be ignored.

@mplachta @filipgolonka @ftrrtf 