### PR TITLE
buildUserData makes some invalid assumptions.

### DIFF
--- a/Helper/UserHelper.php
+++ b/Helper/UserHelper.php
@@ -14,11 +14,16 @@ class UserHelper
     public function buildUserData($user)
     {
         $userData = array();
-        $userData['id'] = method_exists($user, 'getId')
-            ? $user->getId()
-            : (string) $user;
+        if(method_exists($user, 'getId')) 
+        {
+            $userData['id'] = $user->getId();  
+        }
+        else
+        {
+            $userData['id'] = $user->getUsername();
+        }
 
-        $userData['username'] = (string) $user;
+        $userData['username'] = $user->getUsername();
 
         if (method_exists($user, 'getEmail')) {
             $userData['email'] = $user->getEmail();

--- a/Rollbar/Environment.php
+++ b/Rollbar/Environment.php
@@ -54,7 +54,7 @@ class Environment extends BaseEnvironment
     /**
      * @param OptionsResolverInterface $resolver
      */
-    protected function setDefaultOptions(OptionsResolverInterface $resolver)
+    protected function setDefaultOptions(OptionsResolver $resolver)
     {
         parent::setDefaultOptions($resolver);
 

--- a/Rollbar/Environment.php
+++ b/Rollbar/Environment.php
@@ -5,7 +5,7 @@ namespace Ftrrtf\RollbarBundle\Rollbar;
 use Ftrrtf\Rollbar\Environment as BaseEnvironment;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Kernel;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * Configure Symfony specific env.


### PR DESCRIPTION
buildUserData assumes that the Symfony user is castable to string (i.e., has a __toString()).

This is by no means guaranteed based on Symfony's UserInterface contract.

Switched string cast to getUsername(), which is guaranteed to exist by contract.