### PR TITLE
possibility for intercepting PHP7 exceptions

### DIFF
--- a/EventListener/RollbarListener.php
+++ b/EventListener/RollbarListener.php
@@ -5,6 +5,7 @@ namespace Ftrrtf\RollbarBundle\EventListener;
 use Ftrrtf\Rollbar\ErrorHandler;
 use Ftrrtf\Rollbar\Notifier;
 use Ftrrtf\RollbarBundle\Helper\UserHelper;
+use Symfony\Component\Console\Event\ConsoleCommandEvent;
 use Symfony\Component\Console\Event\ConsoleExceptionEvent;
 use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
@@ -103,6 +104,14 @@ class RollbarListener
         }
 
         $this->setException($event->getException());
+    }
+
+    /**
+     * @param ConsoleCommandEvent $event
+     */
+    public function onConsoleCommand(ConsoleCommandEvent $event)
+    {
+        $this->errorHandler->registerExceptionHandler($this->notifier);
     }
 
     /**

--- a/Resources/config/server.xml
+++ b/Resources/config/server.xml
@@ -36,6 +36,7 @@
             <tag name="kernel.event_listener" event="kernel.exception" method="onKernelException" priority="-100" />
             <tag name="kernel.event_listener" event="kernel.response" method="onKernelResponse" priority="-200" />
             <tag name="kernel.event_listener" event="kernel.request" method="onKernelRequest" />
+            <tag name="kernel.event_listener" event="console.command" method="onConsoleCommand" />
             <tag name="kernel.event_listener" event="console.exception" method="onConsoleException" />
         </service>
     </services>

--- a/Tests/DependencyInjection/FtrrtfRollbarExtensionTest.php
+++ b/Tests/DependencyInjection/FtrrtfRollbarExtensionTest.php
@@ -117,6 +117,10 @@ class FtrrtfRollbarExtensionTest extends AbstractExtensionTest
                         'method' => 'onKernelRequest',
                     ),
                     array(
+                        'event' => 'console.command',
+                        'method' => 'onConsoleCommand',
+                    ),
+                    array(
                         'event' => 'console.exception',
                         'method' => 'onConsoleException',
                     ),

--- a/spec/Ftrrtf/RollbarBundle/EventListener/RollbarListenerSpec.php
+++ b/spec/Ftrrtf/RollbarBundle/EventListener/RollbarListenerSpec.php
@@ -9,6 +9,7 @@ use Ftrrtf\RollbarBundle\EventListener\RollbarListener;
 use Ftrrtf\RollbarBundle\Helper\UserHelper;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
+use Symfony\Component\Console\Event\ConsoleCommandEvent;
 use Symfony\Component\Console\Event\ConsoleExceptionEvent;
 use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
@@ -68,9 +69,18 @@ class RollbarListenerSpec extends ObjectBehavior
         $this->getException()->shouldReturn(null);
     }
 
+    function it_registers_exception_handler_for_console_command_event(
+        ConsoleCommandEvent $event,
+        ErrorHandler $errorHandler,
+        Notifier $notifier
+    ) {
+        $errorHandler->registerExceptionHandler($notifier)->shouldBeCalled();
+
+        $this->onConsoleCommand($event);
+    }
+
     function it_reports_exception_on_console_exception(Notifier $notifier, \Exception $exception, ConsoleExceptionEvent $event)
     {
-        $this->setException($exception);
         $event->getException()->willReturn($exception);
 
         $notifier->reportException($exception)->shouldBeCalled();
@@ -116,7 +126,7 @@ class RollbarListenerSpec extends ObjectBehavior
         $this->getUserData()->shouldBeNull();
     }
 
-    function it_should_skip_user_data_if_user_is_anonymous(
+    function it_skips_user_data_if_user_is_anonymous(
         TokenStorageInterface $tokenStorage,
         AuthorizationCheckerInterface $authorizationChecker,
         TokenInterface $token,
@@ -130,7 +140,7 @@ class RollbarListenerSpec extends ObjectBehavior
         $this->getUserData()->shouldBeNull();
     }
 
-    function it_get_user_data_if_user_is_defined(
+    function it_gets_user_data_if_user_is_defined(
         TokenStorageInterface $tokenStorage,
         AuthorizationCheckerInterface $authorizationChecker,
         TokenInterface $token,


### PR DESCRIPTION
In terms of new approach for handling errors in PHP7 we would like to be able to catch and report `Throwable` exceptions. Symfony Console catches only `\Exception` so it is not possible to handle that new "kind" using only `onConsoleException` (https://github.com/symfony/symfony/blob/master/src/Symfony/Component/Console/Application.php#L841). So what I did, was to register error handler, just before command runs (https://github.com/symfony/symfony/blob/master/src/Symfony/Component/Console/Application.php#L836) using well-known `ConsoleCommand` event.

I was thinking a lot how to fix that issue, so instead of reporting a problem I also prepared my solution. What do you think about that? 